### PR TITLE
INTERNAL: Update dependencies and support inline attachments

### DIFF
--- a/griddler-amazon_s3_ses.gemspec
+++ b/griddler-amazon_s3_ses.gemspec
@@ -6,11 +6,11 @@ require 'griddler/amazon_s3_ses/version'
 Gem::Specification.new do |spec|
   spec.name          = "griddler-amazon_s3_ses"
   spec.version       = Griddler::AmazonS3SES::VERSION
-  spec.authors       = ["Thomas Blakey"]
-  spec.email         = ["thomas.blakey@appearhere.co.uk"]
+  spec.authors       = ["Neola Dewhurst", "Thomas Blakey"]
+  spec.email         = ["15362875+ngdewhurst@users.noreply.github.com", "thomas.blakey@appearhere.co.uk"]
 
   spec.summary       = %q{Griddler adapter for AWS S3 SES (handle incoming email replies through SES and S3)}
-  spec.homepage      = "https://github.com/appearhere/griddler-amazon_s3_ses"
+  spec.homepage      = "https://github.com/retailzipline/griddler-amazon_s3_ses"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'httparty'
   spec.add_runtime_dependency 'aws-sdk-s3'
 
-  spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.2"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/griddler/amazon_s3_ses/adapter.rb
+++ b/lib/griddler/amazon_s3_ses/adapter.rb
@@ -112,19 +112,23 @@ module Griddler
         message.attachments.map do |attachment|
           ActionDispatch::Http::UploadedFile.new({
             type: attachment.mime_type,
-            filename: attachment.filename,
+            filename: filename_for(attachment),
             tempfile: tempfile_for_attachment(attachment)
           })
         end
       end
 
       def tempfile_for_attachment(attachment)
-        filename = attachment.filename.gsub(/\/|\\/, '_')
+        filename = filename_for(attachment).gsub(/\/|\\/, '_')
         tempfile = Tempfile.new(filename, Dir::tmpdir, encoding: 'ascii-8bit')
         content = attachment.body.decoded
         tempfile.write(content)
         tempfile.rewind
         tempfile
+      end
+
+      def filename_for(attachment)
+        attachment.inline? ? attachment.cid : attachment.filename
       end
 
       def ensure_valid_notification_type!

--- a/lib/griddler/amazon_s3_ses/adapter.rb
+++ b/lib/griddler/amazon_s3_ses/adapter.rb
@@ -137,7 +137,11 @@ module Griddler
 
       def confirm_sns_subscription_request
         confirmation_endpoint = URI.parse(sns_json['SubscribeURL'])
-        Net::HTTP.get confirmation_endpoint
+        begin
+          Net::HTTP.get URI.encode(confirmation_endpoint)
+        rescue
+          Rails.logger.error "Error confirming subscription #{confirmation_endpoint} #{$!.inspect}"
+        end
       end
 
       def s3

--- a/lib/griddler/amazon_s3_ses/adapter.rb
+++ b/lib/griddler/amazon_s3_ses/adapter.rb
@@ -139,11 +139,9 @@ module Griddler
 
       def confirm_sns_subscription_request
         confirmation_endpoint = URI.parse(sns_json['SubscribeURL'])
-        begin
-          Net::HTTP.get URI.encode(confirmation_endpoint)
-        rescue
-          Rails.logger.error "Error confirming subscription #{confirmation_endpoint} #{$!.inspect}"
-        end
+        Net::HTTP.get confirmation_endpoint
+      rescue StandardError
+        Rails.logger.error "Error confirming subscription #{confirmation_endpoint} #{$!.inspect}"
       end
 
       def s3

--- a/lib/griddler/amazon_s3_ses/adapter.rb
+++ b/lib/griddler/amazon_s3_ses/adapter.rb
@@ -27,6 +27,8 @@ module Griddler
           {}
         when :Notification
           ensure_valid_notification_type!
+          return {} if email_json['mail']['commonHeaders'].empty? # some test SNS notifications are like this
+
           sns_json.merge(
             to: recipients,
             from: sender,

--- a/lib/griddler/amazon_s3_ses/adapter.rb
+++ b/lib/griddler/amazon_s3_ses/adapter.rb
@@ -27,7 +27,7 @@ module Griddler
           {}
         when :Notification
           ensure_valid_notification_type!
-          return {} if email_json['mail']['commonHeaders'].empty? # some test SNS notifications are like this
+          return {} if email_json['mail']['commonHeaders'].blank? # some test SNS notifications are like this
 
           sns_json.merge(
             to: recipients,


### PR DESCRIPTION
Changes in this PR:
- Update dependencies
- Support inline images by changing the filename to the content id (cid) that can be used to look up and replace image sources (see https://github.com/retailzipline/zipline-app/pull/10726)
- Log on unsuccessful SNS Topic subscription confirmations
- Return early if the mail common headers are not present