### PR TITLE
BUGFIX: Strip non-UTF_8 characters

### DIFF
--- a/lib/griddler/amazon_s3_ses/adapter.rb
+++ b/lib/griddler/amazon_s3_ses/adapter.rb
@@ -98,10 +98,10 @@ module Griddler
 
       def force_body_to_utf_8_string(message_body)
         # Fallback to an empty string literal to ensure we don't have nil.to_s which returns a frozen string.
-        # A forzen string errors out with the .force_encoding method.
+        # A frozen string errors out with the .force_encoding method.
         body_string = message_body.present? ? message_body.to_s : ""
 
-        body_string.force_encoding(Encoding::UTF_8)
+        body_string.force_encoding(Encoding::UTF_8).encode("UTF-8", invalid: :replace, replace: "")
       end
 
       def raw_headers

--- a/lib/griddler/amazon_s3_ses/adapter.rb
+++ b/lib/griddler/amazon_s3_ses/adapter.rb
@@ -101,7 +101,7 @@ module Griddler
         # A frozen string errors out with the .force_encoding method.
         body_string = message_body.present? ? message_body.to_s : ""
 
-        body_string.force_encoding(Encoding::UTF_8).encode("UTF-8", invalid: :replace, replace: "")
+        body_string.force_encoding(Encoding::UTF_8).scrub
       end
 
       def raw_headers


### PR DESCRIPTION
Fixes bug https://github.com/retailzipline/zipline-app/issues/22477

[Datadog error](https://app.datadoghq.com/apm/resource/zipline-app-web/rack.request/5e962e2a0ad3196d?query=env%3Aproduction%20service%3Azipline-app-web%20operation_name%3Arack.request&env=production&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=2088552050668615054&spanViewType=errors&timeHint=1696512847117&topGraphs=latency%3Alatency%2Chits%3Acount%2Cerrors%3Acount%2CbreakdownAs%3Apercentage&trace=AgAAAYsAC60NwdKP1gAAAAAAAAAYAAAAAEFZc0FDN2MwQUFEeHZ6cFhCdDdtaVVndgAAACQAAAAAMDE4YjAwMGItYzk5NC00Nzg0LWJmMzItNDNjYzdkN2E3NzU5&traceID=3407080055454261221&traces=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&start=1696515505397&end=1696519105397&paused=false)

Visionworks was sending emails that contained non-UTF-8 characters, e.g. `\x93Cancel Order\x94`. This just removes the non-UTF_8 characters.