### PR TITLE
BUGFIX: Fallback to receipients if To common headers is nil

### DIFF
--- a/lib/griddler/amazon_s3_ses/adapter.rb
+++ b/lib/griddler/amazon_s3_ses/adapter.rb
@@ -56,7 +56,7 @@ module Griddler
       end
 
       def recipients
-        email_json['mail']['commonHeaders']['to']
+        email_json['mail']['commonHeaders']['to'] || email_json["receipt"]["recipients"]
       end
 
       def sender

--- a/spec/griddler/amazon_ses_spec.rb
+++ b/spec/griddler/amazon_ses_spec.rb
@@ -75,6 +75,11 @@ describe Griddler::AmazonS3SES::Adapter do
       expected_string = "Hey User,You've received a response! Let's not leave the customer waiting for too long. Reach out to them ASAP! Message &nbsp;[name]&nbsp; ContactMessage Today 3:26 PM Your customer just responded! Campaign: The change Message: \"Stop\" Click here to Reply!"
       expect(Griddler::AmazonS3SES::Adapter.normalize_params(default_params)[:text]&.strip).to eq expected_string
     end
+
+    it 'should fall back to recipients if To common header is not present' do
+      sns_message[:mail][:commonHeaders][:to] = nil
+      expect(Griddler::AmazonS3SES::Adapter.normalize_params(default_params)[:to]).to eq ['hi@example.com']
+    end
   end
 
   let(:default_params) {


### PR DESCRIPTION
Recently ran into an issue where `to` from `#normalize_params` was `nil` because there was no to field in common headers:
```
zipline-production $> email_json['mail']['commonHeaders']
 =>
{"returnPath"=>[REDACTED],
 "from"=>["Zipline Insights <data@retailzipline.com>"],
 "date"=>"Mon, 18 Dec 2023 12:02:39 +0000 (UTC)",
 "messageId"=>[REDACTED],
 "subject"=>[REDACTED]}
```
However, there was a recipients array in the recipient data
```
zipline-production $> email_json["receipt"]
 =>
{"timestamp"=>"2023-12-18T12:02:41.778Z",
 "processingTimeMillis"=>1648,
 "recipients"=>[REDACTED],
 "spamVerdict"=>{"status"=>"PASS"},
 "virusVerdict"=>{"status"=>"PASS"},
 "spfVerdict"=>{"status"=>"PASS"},
 "dkimVerdict"=>{"status"=>"PASS"},
 "dmarcVerdict"=>{"status"=>"PASS"},
 "action"=>
  {"type"=>"S3",
   "topicArn"=>[REDACTED],
   "bucketName"=>[REDACTED],
   "objectKey"=>[REDACTED]}}
```
Let's fall back to email_json["receipt"]["recipients"] if email_json['mail']['commonHeaders']['to'] is `nil`.