### PR TITLE
BUGFIX: Scrub UTF-8 encoded characters from s3 object body

### DIFF
--- a/lib/griddler/amazon_s3_ses/adapter.rb
+++ b/lib/griddler/amazon_s3_ses/adapter.rb
@@ -81,7 +81,7 @@ module Griddler
 
       def message
         @message ||= begin
-          Mail.read_from_string(email_s3_object.get.body.string)
+          Mail.read_from_string(email_s3_object.get.body.string.scrub)
         end
       end
 
@@ -107,7 +107,7 @@ module Griddler
         # A frozen string errors out with the .force_encoding method.
         body_string = message_body.present? ? message_body.to_s : ""
 
-        body_string.force_encoding(Encoding::UTF_8).scrub
+        body_string.force_encoding(Encoding::UTF_8)
       end
 
       def raw_headers


### PR DESCRIPTION
We are receiving an email that contains `\x92` and `Mail.read_from_string` [here](https://github.com/retailzipline/griddler-amazon_s3_ses/blob/main/lib/griddler/amazon_s3_ses/adapter.rb#L84) is failing with
```
ArgumentError
invalid byte sequence in UTF-8
/app/vendor/bundle/ruby/3.2.0/gems/mail-2.8.1/lib/mail/message.rb:2015:in `match'
/app/vendor/bundle/ruby/3.2.0/gems/mail-2.8.1/lib/mail/message.rb:2015:in `match'
/app/vendor/bundle/ruby/3.2.0/gems/mail-2.8.1/lib/mail/message.rb:2015:in `set_envelope_header'
/app/vendor/bundle/ruby/3.2.0/gems/mail-2.8.1/lib/mail/message.rb:2118:in `init_with_string'
/app/vendor/bundle/ruby/3.2.0/gems/mail-2.8.1/lib/mail/message.rb:135:in `initialize'
/app/vendor/bundle/ruby/3.2.0/gems/mail-2.8.1/lib/mail/mail.rb:51:in `new'
/app/vendor/bundle/ruby/3.2.0/gems/mail-2.8.1/lib/mail/mail.rb:51:in `new'
/app/vendor/bundle/ruby/3.2.0/gems/mail-2.8.1/lib/mail/mail.rb:180:in `read_from_string'
/app/vendor/bundle/ruby/3.2.0/bundler/gems/griddler-amazon_s3_ses-d50073ede7bd/lib/griddler/amazon_s3_ses/adapter.rb:84:in `message'
/app/vendor/bundle/ruby/3.2.0/bundler/gems/griddler-amazon_s3_ses-d50073ede7bd/lib/griddler/amazon_s3_ses/adapter.rb:89:in `multipart?'
/app/vendor/bundle/ruby/3.2.0/bundler/gems/griddler-amazon_s3_ses-d50073ede7bd/lib/griddler/amazon_s3_ses/adapter.rb:93:in `text_part'
/app/vendor/bundle/ruby/3.2.0/bundler/gems/griddler-amazon_s3_ses-d50073ede7bd/lib/griddler/amazon_s3_ses/adapter.rb:39:in `normalize_params'
/app/vendor/bundle/ruby/3.2.0/bundler/gems/griddler-amazon_s3_ses-d50073ede7bd/lib/griddler/amazon_s3_ses/adapter.rb:17:in `normalize_params'
```

This moves the `.scrub` from https://github.com/retailzipline/griddler-amazon_s3_ses/pull/3 to scrub the s3 object body as we load it.

Sentry error: https://retail-zipline.sentry.io/issues/4917993847/?referrer=slack&notification_uuid=c3746692-ed00-4e0c-9a66-df68603e58fc&environment=production&alert_rule_id=2580037&alert_type=issue

Additional context from [Slack thread](https://zipline.slack.com/archives/C01E7GZ1V0S/p1706278663700229)