### PR TITLE
BUGFIX: Add .scrub back on the body force encoding

### DIFF
--- a/lib/griddler/amazon_s3_ses/adapter.rb
+++ b/lib/griddler/amazon_s3_ses/adapter.rb
@@ -107,7 +107,7 @@ module Griddler
         # A frozen string errors out with the .force_encoding method.
         body_string = message_body.present? ? message_body.to_s : ""
 
-        body_string.force_encoding(Encoding::UTF_8)
+        body_string.force_encoding(Encoding::UTF_8).scrub
       end
 
       def raw_headers


### PR DESCRIPTION
I removed the `.scrub` in https://github.com/retailzipline/griddler-amazon_s3_ses/pull/7 and didn't realize that it is still necessary even though we're now ALSO scrubbing the message that is downloaded from S3.

The issue is that the email body can have characters not UTF-8 compatible (e.g. ©) that can be read by `Mail` when we download from S3, but when we force the encoding to UTF-8, those characters are converted to the `\xA9` form that breaks the body parsing.

This adds the scrub back to the body as well.

Slack thread: https://zipline.slack.com/archives/C01E7GZ1V0S/p1706559463790249