### PR TITLE
Extract recipients separately

### DIFF
--- a/lib/griddler/amazon_s3_ses/adapter.rb
+++ b/lib/griddler/amazon_s3_ses/adapter.rb
@@ -31,7 +31,8 @@ module Griddler
           return {} if email_json['mail']['commonHeaders'].blank? # some test SNS notifications are like this
 
           sns_json.merge(
-            to: recipients,
+            to: to,
+            recipients: recipients,
             from: sender,
             cc: cc,
             bcc: bcc,
@@ -55,8 +56,12 @@ module Griddler
         email_json['notificationType']
       end
 
-      def recipients
+      def to
         email_json['mail']['commonHeaders']['to'] || email_json["receipt"]["recipients"]
+      end
+
+      def recipients
+        email_json["receipt"]["recipients"]
       end
 
       def sender

--- a/spec/griddler/amazon_ses_spec.rb
+++ b/spec/griddler/amazon_ses_spec.rb
@@ -32,6 +32,18 @@ describe Griddler::AmazonS3SES::Adapter do
       expect(Griddler::AmazonS3SES::Adapter.normalize_params(default_params)[:to]).to eq ['"Mr Fugushima at Fugu, Inc" <hi@example.com>', 'Foo bar <foo@example.com>']
     end
 
+    it 'parses out the "recipients" addresses, returning an array' do
+      expect(Griddler::AmazonS3SES::Adapter.normalize_params(default_params)[:recipients]).to eq ['hi@example.com']
+    end
+
+    it 'parses out the "to" addresses, fallin back to the "recipients" addresse' do
+      default_params['Message'] = JSON.parse(default_params['Message']).tap do
+        _1.dig('mail', 'commonHeaders').delete('to')
+      end.to_json
+
+      expect(Griddler::AmazonS3SES::Adapter.normalize_params(default_params)[:to]).to eq ['hi@example.com']
+    end
+
     it 'parses out the "from" address, returning a string' do
       expect(Griddler::AmazonS3SES::Adapter.normalize_params(default_params)[:from]).to eq "Test There <there@example.com>"
     end


### PR DESCRIPTION
In #6 we added a fallback to the SES receipt/recipients attribute for the receiver. This additionally exposes that attribute to the returned hash.

The reason is that if a customer sends to a configured group or subscription email address, the "to" header will include the group address and not the final recipient. So if the group is something like "allstoreslist@zipline.inc" and that group includes "tid.59-workflows-zipline@zipline.inc" and "tid.58-workflows-zipline@zipline.inc" the "to" value will come into the Zipline email processor as "allstoreslist@zipline.inc" - it'll fail to get processed as a workflow because it doesn't contain the string "workflow".

If we use the actual recipients list from SES then we can correctly process these group bound emails.

This request came from Tillys, I've verified it manually using a custom group using @zipline.inc. Related change will come on the main repo...