### PR TITLE
Replace httparty with Net::HTTP from stdlib

### DIFF
--- a/griddler-amazon_s3_ses.gemspec
+++ b/griddler-amazon_s3_ses.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'griddler'
   spec.add_runtime_dependency 'mail'
-  spec.add_runtime_dependency 'httparty'
   spec.add_runtime_dependency 'aws-sdk-s3'
   spec.add_runtime_dependency 'sanitize'
 

--- a/lib/aws/sns_message.rb
+++ b/lib/aws/sns_message.rb
@@ -17,7 +17,8 @@
 require 'base64'
 require 'json'
 require 'openssl'
-require 'httparty'
+require 'net/http'
+require 'uri'
 
 module AWS
   class MessageWasNotAuthenticError < StandardError
@@ -144,8 +145,7 @@ module AWS
       raise MessageWasNotAuthenticError, "cert is not hosted at AWS URL (https): #{url}" unless url =~ /^https.*amazonaws\.com\/.*$/i
       tries = 0
       begin
-        response = HTTParty.get url
-        response.body
+        Net::HTTP.get(URI.parse(url))
       rescue => msg
         tries += 1
         retry if tries <= 3


### PR DESCRIPTION
## Summary
- Replaces the `httparty` gem with Ruby's built-in `Net::HTTP` for fetching AWS SNS signing certificates
- Removes `httparty` from the gemspec runtime dependencies
- The only usage was a single `GET` request, so the external dependency was unnecessary

Rather than bumping httparty to patch CVE-2025-68696 (see retailzipline/zipline-app#41893), this removes the dependency entirely.

Now, I know that @raySavignone is planning to get rid of griddler so maybe we don't need to make that change. It seems low risk to me, I'm happy to take care of deploying this.